### PR TITLE
Fix language labels and make initialization async in admin panel

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2351,6 +2351,7 @@ var appAdminTemplate = template.Must(template.New("appAdmin").Parse(`<!doctype h
 				baseUrlAdded: 'Base URL added',
 				baseUrlRemoved: 'Base URL removed'
 			},
+			'zh-hans': {
 				adminTitle: '🐱 NekoLc 管理面板',
 				logout: '登出',
 				navStats: '📊 统计',
@@ -2463,6 +2464,7 @@ var appAdminTemplate = template.Must(template.New("appAdmin").Parse(`<!doctype h
 				baseUrlAdded: '已添加基础 URL',
 				baseUrlRemoved: '已移除基础 URL'
 			},
+			'zh-hant': {
 				adminTitle: '🐱 NekoLc 管理面板',
 				logout: '登出',
 				navStats: '📊 統計',
@@ -3938,10 +3940,12 @@ var appAdminTemplate = template.Must(template.New("appAdmin").Parse(`<!doctype h
 		}
 		
 		// Initialize
-		checkAuth();
-		applyLang();
-		renderBaseUrlPresets();
-		loadStats();
+		(async () => {
+			await checkAuth();
+			applyLang();
+			renderBaseUrlPresets();
+			loadStats();
+		})();
 	</script>
 </body>
 </html>`))


### PR DESCRIPTION
## Summary
This PR fixes missing language identifiers in the admin panel template and refactors the initialization sequence to use async/await pattern.

## Key Changes
- Added missing `'zh-hans'` language identifier for Simplified Chinese translations
- Added missing `'zh-hant'` language identifier for Traditional Chinese translations
- Wrapped initialization function calls in an async IIFE to properly await `checkAuth()` before executing subsequent initialization steps

## Implementation Details
The language identifiers were previously missing their keys in the translation object, which would have caused the Chinese language options to not be properly registered. The initialization refactoring ensures that authentication is checked asynchronously before proceeding with language application, base URL preset rendering, and statistics loading, preventing potential race conditions during page load.

https://claude.ai/code/session_01E2xoEgBJkgL7n2L7LhhGne