### PR TITLE
Security hardening: response headers, WebSocket origin check, account rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,11 +316,22 @@ Uploaded files are served at `/files/<path>` with path-traversal protection.
 
 ## Running Behind a Reverse Proxy
 
+> [!WARNING]
+> **Do not expose the server directly to the public internet.** The server
+> unconditionally trusts the `X-Forwarded-For` / `X-Real-IP` headers when
+> identifying client IPs for rate limiting (login, registration, password
+> reset, email verification). Without a trusted reverse proxy in front,
+> an attacker can spoof these headers to bypass rate limits entirely.
+> Always deploy behind a reverse proxy (Nginx, Caddy, etc.) that
+> **overwrites** these headers with the real client address, and make sure
+> the application port (e.g. `8080`) is only reachable from the proxy
+> (bind to `127.0.0.1` or restrict it with a firewall).
+
 If you run NekoLc Server behind Nginx, Caddy, or another reverse proxy:
 
 1. Set `server.basePath` if the server is not at the root (e.g. `"/launcher"`)
 2. Set `smtp.baseUrl` to your public URL so email links work correctly
-3. Forward the `X-Forwarded-For` header for accurate rate limiting
+3. Forward the `X-Forwarded-For` header for accurate rate limiting — the proxy must **set/overwrite** it, never pass through the client-supplied value
 
 **Nginx example:**
 

--- a/internal/server/account.go
+++ b/internal/server/account.go
@@ -58,6 +58,17 @@ func userIDFromClaims(c *authClaims) (int64, error) {
 	return strconv.ParseInt(parts[1], 10, 64)
 }
 
+// accountRateLimited reports whether the request exceeds the limit for sensitive
+// account endpoints. When the limit is hit it writes a 429 response and returns
+// true so the caller can abort.
+func (s *Server) accountRateLimited(w http.ResponseWriter, r *http.Request) bool {
+	if s.accountLimiter != nil && !s.accountLimiter.Allow(clientIP(r)) {
+		s.writeError(w, http.StatusTooManyRequests, s.appConfig.Language.Default, "TooManyRequests", "Too many requests. Please try again later.")
+		return true
+	}
+	return false
+}
+
 // requireUser authenticates the request and loads the corresponding user.
 func (s *Server) requireUser(r *http.Request) (*store.User, error) {
 	claims, err := s.authenticate(r)
@@ -154,6 +165,9 @@ func (s *Server) handleAppForgotPassword(w http.ResponseWriter, r *http.Request)
 		s.writeError(w, http.StatusNotImplemented, s.appConfig.Language.Default, "NotImplemented", "Account store not configured")
 		return
 	}
+	if s.accountRateLimited(w, r) {
+		return
+	}
 	var req ForgotPasswordRequest
 	if err := s.decode(r, &req); err != nil {
 		s.writeError(w, http.StatusBadRequest, s.appConfig.Language.Default, "InvalidRequest", err.Error())
@@ -187,6 +201,9 @@ type ResetPasswordRequest struct {
 func (s *Server) handleAppResetPassword(w http.ResponseWriter, r *http.Request) {
 	if s.store == nil {
 		s.writeError(w, http.StatusNotImplemented, s.appConfig.Language.Default, "NotImplemented", "Account store not configured")
+		return
+	}
+	if s.accountRateLimited(w, r) {
 		return
 	}
 	var req ResetPasswordRequest
@@ -226,6 +243,9 @@ func (s *Server) handleAppSendVerification(w http.ResponseWriter, r *http.Reques
 		s.writeError(w, http.StatusNotImplemented, s.appConfig.Language.Default, "NotImplemented", "Authentication is disabled")
 		return
 	}
+	if s.accountRateLimited(w, r) {
+		return
+	}
 	user, err := s.requireUser(r)
 	if err != nil {
 		s.writeError(w, http.StatusUnauthorized, s.appConfig.Language.Default, "Unauthorized", "invalid credentials")
@@ -254,6 +274,9 @@ type VerifyEmailRequest struct {
 func (s *Server) handleAppVerifyEmail(w http.ResponseWriter, r *http.Request) {
 	if s.store == nil {
 		s.writeError(w, http.StatusNotImplemented, s.appConfig.Language.Default, "NotImplemented", "Account store not configured")
+		return
+	}
+	if s.accountRateLimited(w, r) {
 		return
 	}
 	token := strings.TrimSpace(r.URL.Query().Get("token"))

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -16,6 +16,14 @@ const (
 	loginRateLimitWindow = time.Minute
 )
 
+// Default policy for sensitive, unauthenticated account endpoints (registration,
+// password reset, email verification). These are kept stricter than login to
+// curb email-sending abuse, token brute-forcing and account enumeration.
+const (
+	accountRateLimitMax    = 5
+	accountRateLimitWindow = time.Minute
+)
+
 // rateLimiter is a simple in-memory sliding-window rate limiter keyed by an
 // arbitrary string (typically the client IP).
 type rateLimiter struct {

--- a/internal/server/security_headers.go
+++ b/internal/server/security_headers.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// contentSecurityPolicy is applied to every response. The admin/account UIs rely
+// on inline <script>/<style> blocks and inline event-handler attributes, so
+// script-src and style-src must permit 'unsafe-inline'. The policy still blocks
+// loading scripts, styles, frames and objects from foreign origins, forbids the
+// pages from being framed (clickjacking), and constrains form submissions and
+// the document base URI. img-src allows https and data: so admin-configured
+// poster/avatar URLs render; connect-src allows ws/wss for the live WebSocket.
+const contentSecurityPolicy = "default-src 'self'; " +
+	"script-src 'self' 'unsafe-inline'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' data: https:; " +
+	"font-src 'self' data:; " +
+	"connect-src 'self' ws: wss:; " +
+	"frame-ancestors 'none'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'; " +
+	"object-src 'none'"
+
+// securityHeadersMiddleware sets defensive HTTP response headers on every
+// response: a Content-Security-Policy, MIME-sniffing protection, clickjacking
+// protection and a privacy-preserving Referrer-Policy.
+func securityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "no-referrer")
+		h.Set("Content-Security-Policy", contentSecurityPolicy)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// sameOriginWebSocket reports whether a WebSocket upgrade request may proceed.
+// Requests without an Origin header (non-browser clients such as the launcher)
+// are allowed. Browser-originated requests are only allowed when the Origin host
+// matches the request Host, defeating Cross-Site WebSocket Hijacking. The
+// connection is still unauthenticated until a valid access token is presented,
+// so this is defence-in-depth.
+func sameOriginWebSocket(r *http.Request) bool {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(u.Host, r.Host)
+}

--- a/internal/server/security_test.go
+++ b/internal/server/security_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -52,5 +54,56 @@ func TestResolveSafePathAllowsWithinBase(t *testing.T) {
 	absBase, _ := filepath.Abs(base)
 	if !pathWithinBase(resolved, absBase) {
 		t.Fatalf("resolved path %q should be within base %q", resolved, absBase)
+	}
+}
+
+// TestSecurityHeadersMiddleware ensures the defensive response headers are set.
+func TestSecurityHeadersMiddleware(t *testing.T) {
+	handler := securityHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/app", nil))
+
+	want := map[string]string{
+		"X-Content-Type-Options": "nosniff",
+		"X-Frame-Options":        "DENY",
+		"Referrer-Policy":        "no-referrer",
+	}
+	for k, v := range want {
+		if got := rec.Header().Get(k); got != v {
+			t.Errorf("header %q = %q, want %q", k, got, v)
+		}
+	}
+	if rec.Header().Get("Content-Security-Policy") == "" {
+		t.Errorf("expected a Content-Security-Policy header to be set")
+	}
+}
+
+// TestSameOriginWebSocket validates the Cross-Site WebSocket Hijacking guard.
+func TestSameOriginWebSocket(t *testing.T) {
+	cases := []struct {
+		name   string
+		origin string
+		host   string
+		allow  bool
+	}{
+		{"no origin (non-browser client)", "", "example.com", true},
+		{"matching origin", "https://example.com", "example.com", true},
+		{"matching origin with port", "http://example.com:8080", "example.com:8080", true},
+		{"cross origin", "https://evil.com", "example.com", false},
+		{"malformed origin", "://bad", "example.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/v0/ws", nil)
+			r.Host = tc.host
+			if tc.origin != "" {
+				r.Header.Set("Origin", tc.origin)
+			}
+			if got := sameOriginWebSocket(r); got != tc.allow {
+				t.Errorf("sameOriginWebSocket(origin=%q, host=%q) = %v, want %v", tc.origin, tc.host, got, tc.allow)
+			}
+		})
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -62,6 +62,7 @@ type Server struct {
 	dirCache              map[string]dirCacheEntry
 	updateConfigMu        sync.RWMutex
 	loginLimiter          *rateLimiter
+	accountLimiter        *rateLimiter
 	wsHub                 *wsHub
 }
 
@@ -113,6 +114,7 @@ func New(
 		basePath:              normalizeBasePath(appCfg.Server.BasePath),
 		dirCache:              map[string]dirCacheEntry{},
 		loginLimiter:          newRateLimiter(loginRateLimitMax, loginRateLimitWindow),
+		accountLimiter:        newRateLimiter(accountRateLimitMax, accountRateLimitWindow),
 	}
 	// Resolve the WebSocket mount path (defaults to /v0/ws).
 	srv.wsPath = strings.TrimSpace(appCfg.WebSocket.Path)
@@ -186,6 +188,7 @@ func (s *Server) buildRouter() chi.Router {
 	r.Use(middleware.RealIP)
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+	r.Use(securityHeadersMiddleware)
 	r.Use(s.apiTrackingMiddleware)
 
 	mount := func(router chi.Router) {
@@ -1417,6 +1420,9 @@ func (s *Server) handleAppRegisterSubmit(w http.ResponseWriter, r *http.Request)
 	}
 	if acct := s.currentAccountConfig(); acct != nil && !acct.AllowRegistration {
 		s.writeError(w, http.StatusForbidden, s.appConfig.Language.Default, "Unauthorized", "registration is disabled")
+		return
+	}
+	if s.accountRateLimited(w, r) {
 		return
 	}
 	var payload RegisterPayload

--- a/internal/server/websocket.go
+++ b/internal/server/websocket.go
@@ -130,9 +130,9 @@ func (h *wsHub) Broadcast(notification *WSNotification) {
 var wsUpgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
-	CheckOrigin: func(r *http.Request) bool {
-		return true // Allow all origins; tighten in production via reverse proxy
-	},
+	// Reject cross-origin upgrade requests to prevent Cross-Site WebSocket
+	// Hijacking. Non-browser clients (no Origin header) are still allowed.
+	CheckOrigin: sameOriginWebSocket,
 }
 
 // --- WebSocket Constants ---


### PR DESCRIPTION
## Summary

Follow-up from a full security review of the codebase (XSS / CSRF / SSRF / path traversal and related surfaces). The review confirmed the existing defences are solid — parameterized SQL, `html/template` auto-escaping (including `javascript:` URL neutralization), escape-before-format Markdown rendering with a URL scheme allowlist, robust `resolveSafePath` path-traversal guards, bcrypt + crypto/rand + constant-time comparisons, and SMTP header sanitization. This PR hardens the remaining gaps:

### Changes

- **Security response headers** (`internal/server/security_headers.go`): new middleware applied to every response — `Content-Security-Policy` (`frame-ancestors 'none'`, `object-src 'none'`, self-restricted script/style/connect sources), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`. CSP keeps `'unsafe-inline'` for script/style since the admin and account pages rely on inline scripts and event-handler attributes.
- **WebSocket origin validation** (`internal/server/websocket.go`): `CheckOrigin` previously allowed all origins, enabling Cross-Site WebSocket Hijacking from any site. Upgrades now require the `Origin` host to match the request `Host`; requests without an `Origin` header (non-browser launcher clients) are still allowed.
- **Rate limiting on sensitive account endpoints** (`internal/server/ratelimit.go`, `account.go`, `server.go`): registration, forgot/reset password, and email verification endpoints are now limited to 5 requests/minute per IP (login already had its own limiter), curbing token brute-forcing, account enumeration, and email-sending abuse.
- **Deployment warning** (`README.md`): prominent warning that `X-Forwarded-For` / `X-Real-IP` are trusted for rate-limit client identification, so the server must not be exposed directly to the public internet — it must sit behind a reverse proxy that overwrites these headers, with the app port firewalled or bound to localhost.

### Testing

- New unit tests for the security-headers middleware and the same-origin WebSocket guard (`internal/server/security_test.go`).
- `go vet ./...` and `go test ./...` pass.

https://claude.ai/code/session_01RSo8S1VSoFcjuH5U2jCEAe

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSo8S1VSoFcjuH5U2jCEAe)_